### PR TITLE
Progressive Github permissioning & client-side oauth tokens

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -46,7 +46,8 @@
                  [org.clojure/tools.nrepl "0.2.12"]
                  [com.cemerick/piggieback "0.2.1"]
                  [jarohen/chime "0.2.0"]
-                 [com.andrewmcveigh/cljs-time "0.4.0"]]
+                 [com.andrewmcveigh/cljs-time "0.4.0"]
+                 [akiroz.re-frame/storage "0.1.1"]]
 
   :min-lein-version "2.0.0"
   :source-paths ["src/clj" "src/cljc"]

--- a/resources/migrations/20170322212119-do-not-store-oauth-token-in-db.up.sql
+++ b/resources/migrations/20170322212119-do-not-store-oauth-token-in-db.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."users" DROP COLUMN "token";

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -3,14 +3,13 @@
 -- :name create-user! :<! :1
 -- :doc creates a new user record
 INSERT INTO users
-(id, login, name, email, avatar_url, token, address, created)
+(id, login, name, email, avatar_url, address, created)
 SELECT
   :id,
   :login,
   :name,
   :email,
   :avatar_url,
-  :token,
   :address,
   :created
 WHERE NOT exists(SELECT 1
@@ -24,16 +23,8 @@ UPDATE users
 SET login = :login,
 name = :name,
 email = :email,
-token = :token,
 address = :address
 WHERE id = :id;
-
--- :name update-user-token! :<! :1
--- :doc updates user token and returns updated user
-UPDATE users
-SET token = :token
-WHERE id = :id
-RETURNING id, login, name, email, token, address, created;
 
 -- :name update-user-address! :! :n
 UPDATE users

--- a/resources/templates/home.html
+++ b/resources/templates/home.html
@@ -25,13 +25,15 @@
     var context = "{{servlet-context}}";
     var csrfToken = "{{csrf-token}}";
     var authorizeUrl = "{{authorize-url}}";
+    var authorizeUrlAdmin = "{{authorize-url-admin}}";
     var token = "{{token}}";
-    var userId = "{{userId}}";
+    var adminToken = "{{admin-token}}";
+    var userId = "{{user-id}}";
     var user = "{{login}}";
     if (user === "") {
         user = null;
     }
-    var commitethVersion = "{{commitethVersion}}";
+    var commitethVersion = "{{commiteth-version}}";
 </script>
 
 {% style "https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.1.8/semantic.min.css" %}

--- a/src/clj/commiteth/db/users.clj
+++ b/src/clj/commiteth/db/users.clj
@@ -5,14 +5,13 @@
   (:import [java.util Date]))
 
 (defn create-user
-  [user-id login name email avatar-url token]
+  [user-id login name email avatar-url]
   (jdbc/with-db-connection [con-db *db*]
     (db/create-user! con-db
       {:id      user-id
        :login   login
        :name    name
        :email   email
-       :token   token
        :avatar_url avatar-url
        :address nil
        :created (new Date)})))
@@ -32,12 +31,6 @@
   (log/debug "update-user-address" user-id address)
   (jdbc/with-db-connection [con-db *db*]
     (db/update-user-address! con-db {:id user-id :address address})))
-
-(defn update-user-token
-  "Updates user token and returns updated user"
-  [user-id token]
-  (jdbc/with-db-connection [con-db *db*]
-    (db/update-user-token! con-db {:id user-id :token token})))
 
 (defn get-repo-owner
   "Gets repository owner by given repository id"

--- a/src/clj/commiteth/layout.clj
+++ b/src/clj/commiteth/layout.clj
@@ -4,8 +4,7 @@
             [markdown.core :refer [md-to-html-string]]
             [ring.util.http-response :refer [content-type ok]]
             [ring.util.anti-forgery :refer [anti-forgery-field]]
-            [ring.middleware.anti-forgery :refer [*anti-forgery-token*]]
-            [commiteth.github.core :as github]))
+            [ring.middleware.anti-forgery :refer [*anti-forgery-token*]]))
 
 (parser/set-resource-path! (clojure.java.io/resource "templates"))
 (parser/add-tag! :csrf-field (fn [_ _] (anti-forgery-field)))
@@ -19,7 +18,6 @@
       (parser/render-file
         template
         (assoc params
-          :authorize-url (github/authorize-url)
           :page template
           :csrf-token *anti-forgery-token*)))
     "text/html; charset=utf-8"))

--- a/src/clj/commiteth/routes/home.clj
+++ b/src/clj/commiteth/routes/home.clj
@@ -1,5 +1,6 @@
 (ns commiteth.routes.home
   (:require [commiteth.layout :as layout]
+            [commiteth.github.core :as github]
             [compojure.core :refer [defroutes GET]]
             [ring.util.response :refer [redirect]]
             [ring.util.http-response :refer [ok header]]
@@ -8,15 +9,21 @@
 
 (defonce ^:const version (System/getProperty "commiteth.version"))
 
-(defn home-page [{user-id :id login :login token :token}]
-  (layout/render "home.html" {:userId user-id
+(defn home-page [{user-id :id
+                  login :login
+                  token :token
+                  admin-token :admin-token}]
+  (layout/render "home.html" {:user-id user-id
                               :login login
                               :token token
-                              :commitethVersion version}))
+                              :admin-token admin-token
+                              :authorize-url (github/signup-authorize-url)
+                              :authorize-url-admin (github/admin-authorize-url)
+                              :commiteth-version version}))
 
 (defroutes home-routes
-  (GET "/" {{identity :identity} :session}
-       (home-page identity))
+  (GET "/" {{user :identity} :session}
+       (home-page user))
   (GET "/logout" {session :session}
        (-> (redirect "/")
            (assoc :session (dissoc session :identity)))))

--- a/src/clj/commiteth/routes/redirect.clj
+++ b/src/clj/commiteth/routes/redirect.clj
@@ -9,7 +9,8 @@
             [ring.util.response :as response]
             [commiteth.layout :refer [render]]
             [cheshire.core :refer [generate-string]]
-            [clojure.tools.logging :as log]))
+            [clojure.tools.logging :as log]
+            [clojure.string :as str]))
 
 
 
@@ -19,7 +20,7 @@
          user-id :id
          avatar-url :avatar_url} user
         email (github/get-user-email token)]
-    (users/create-user user-id login name email avatar-url token)))
+    (users/create-user user-id login name email avatar-url)))
 
 (defn- get-or-create-user
   [token]
@@ -28,17 +29,22 @@
          user-id :id} user]
     (log/debug "get-or-create-user" user)
     (or
-      (users/update-user-token user-id token)
+      (users/get-user user-id)
       (create-user token user))))
 
 (defroutes redirect-routes
   (GET "/callback" [code state]
     (let [resp         (github/post-for-token code state)
           body         (keywordize-keys (codec/form-decode (:body resp)))
+          scope        (:scope body)
           access-token (:access_token body)]
+      (log/debug "github sign-in callback, response body:" body)
       (if (:error body)
         ;; Why does Mist browser sends two redirects at the same time? The latter results in 401 error.
         (response/redirect "/")
-        (let [user (get-or-create-user access-token)]
+        (let [admin-token? (str/includes? scope "repo")
+              token-key (if admin-token? :admin-token :token)
+              user (-> (get-or-create-user access-token)
+                       (assoc token-key access-token))]
           (-> (response/redirect "/")
             (assoc :session {:identity user})))))))

--- a/src/cljs/commiteth/core.cljs
+++ b/src/cljs/commiteth/core.cljs
@@ -173,18 +173,22 @@
 
 (defn load-user []
   (if-let [login js/user]
-    (when-not (= login @active-user)
-      (println "active user changed, loading user data")
-      (reset! active-user login)
-      (rf/dispatch [:set-active-user
-                    {:login login
-                     :id (js/parseInt js/userId)
-                     :token js/token}]))
+    (if (= login @active-user)
+      (do
+        (println "refresh with active user, updating tokens")
+        (rf/dispatch [:update-tokens js/token js/adminToken]))
+      (do
+        (println "active user changed, loading user data")
+        (reset! active-user login)
+        (rf/dispatch [:set-active-user
+                      {:login login
+                       :id (js/parseInt js/userId)}
+                      js/token
+                      js/adminToken])))
     (reset! active-user nil)))
 
 (defn load-data []
-  (doall
-   (map rf/dispatch
+  (doall (map rf/dispatch
         [[:load-open-bounties]
          [:load-activity-feed]
          [:load-top-hunters]]))

--- a/src/cljs/commiteth/db.cljs
+++ b/src/cljs/commiteth/db.cljs
@@ -8,4 +8,6 @@
    :open-bounties []
    :owner-bounties   {}
    :top-hunters []
-   :activity-feed []})
+   :activity-feed []
+   :gh-token nil
+   :gh-admin-token nil})

--- a/src/cljs/commiteth/repos.cljs
+++ b/src/cljs/commiteth/repos.cljs
@@ -54,8 +54,8 @@
                  (into [:div.ui.cards]
                        (map repo-card group-repos))]))))))
 
-
-(defn repos-page []
+(defn repos-page-token-ok []
+  (println "repos-token-ok")
   (let [repos-loading? (rf/subscribe [:repos-loading?])]
     (fn []
       (if @repos-loading?
@@ -63,3 +63,15 @@
          [:div.ui.active.inverted.dimmer
           [:div.ui.text.loader "Loading"]]]
         [repos-list]))))
+
+(defn repos-page []
+  (let [gh-admin-token (rf/subscribe [:gh-admin-token])]
+    (fn []
+      (println "gh-admin-token" @gh-admin-token)
+      (if (empty? @gh-admin-token)
+        [:div.ui.container
+         [:div.ui.warning.message
+          [:i.warning.icon]
+          "To set bounties for your repositories or for organizations' repositories where you have access, you need to grant Commit ETH the required permissions"]
+         [:a.ui.button.small {:href js/authorizeUrlAdmin} "Enable"]]
+        [repos-page-token-ok]))))

--- a/src/cljs/commiteth/subscriptions.cljs
+++ b/src/cljs/commiteth/subscriptions.cljs
@@ -52,6 +52,11 @@
     (:activity-feed db)))
 
 (reg-sub
+  :gh-admin-token
+  (fn [db _]
+    (:gh-admin-token db)))
+
+(reg-sub
   :get-in
   (fn [db [_ path]]
     (get-in db path)))


### PR DESCRIPTION
* require only user:email oauth scope when signing up
* if user wants to set bounties on repos, request additional oauth
  scopes
* do not store github access tokens on server side and use client-side
  localStorage instead

Fixes: #35
Fixes: #40