### PR TITLE
[bug] fix dropdown menu

### DIFF
--- a/src/cljs/commiteth/core.cljs
+++ b/src/cljs/commiteth/core.cljs
@@ -37,8 +37,8 @@
 
 (defn user-dropdown [user items]
   (let [menu (if @user-dropdown-open?
-                  [:div.ui.menu.transition.visible]
-                  [:div.ui.menu.transition.hidden])
+               [:div.ui.menu.transition.visible]
+               [:div.ui.menu.transition.hidden])
         avatar-url (:avatar_url user)]
     [:div.ui.left.item.dropdown
      {:on-click #(swap! user-dropdown-open? not)}
@@ -185,9 +185,10 @@
         show-top-hunters? #(contains? #{:bounties :activity} @current-page)]
     (fn []
       [:div.ui.pusher
+       [:div.vertical.commiteth-background.wide]
        [page-header]
        [:div.ui.vertical.segment
-        [:div.ui.container
+        [:div.ui.container.page
          [:div.ui.grid.stackable
           [:div {:class (str (if (show-top-hunters?) "ten" "sixteen")
                              " wide computer sixteen wide tablet column")}

--- a/src/less/style.less
+++ b/src/less/style.less
@@ -45,12 +45,21 @@
 
 
 .commiteth-header {
-    background-color: #57a7ed!important;
     border-radius: 0em;
     padding-top: 1.5em;
     padding-bottom: 2.5em;
+    z-index: 1;
 }
 
+.commiteth-background {
+    background-color: #57a7ed!important;
+    width: 100%;
+    height: 150px;
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: -2;
+}
 
 .status-logo {
     width: 42px;
@@ -173,8 +182,7 @@
     border-radius: 8px;
     border: none;
     padding: .5em;
-    z-index: 999;
-    transform: translate(100%, -100%);
+    visibility: hidden;
     .item>a {
         color: #fff;
         pointer: default;
@@ -430,6 +438,10 @@
 
 }
 
+.ui.container.page {
+    z-index: -1;
+    position: relative;
+}
 
 .ui.cards>.card  {
     border: #e7e7e7 solid 0.1em;


### PR DESCRIPTION
Fixes the dropdown menu by moving the background color of the header into a separate div with position absolute. This allows us to have the page overlap with the header background while still being able to set a higher z-index for the header itself preventing the dropdown from being hidden by the page.