### PR TITLE
[bug] close dropdown when clicking outside of it

### DIFF
--- a/src/cljs/commiteth/core.cljs
+++ b/src/cljs/commiteth/core.cljs
@@ -36,12 +36,12 @@
 (def user-dropdown-open? (r/atom false))
 
 (defn user-dropdown [user items]
-  (let [menu (if @user-dropdown-open?
+  (let [menu (if @(rf/subscribe [:user-dropdown-open?])
                [:div.ui.menu.transition.visible]
                [:div.ui.menu.transition.hidden])
         avatar-url (:avatar_url user)]
     [:div.ui.left.item.dropdown
-     {:on-click #(swap! user-dropdown-open? not)}
+     {:on-click #(rf/dispatch [:user-dropdown-open])}
      [:div.item
       [:img.ui.mini.circular.image {:src avatar-url}]]
      [:div.item

--- a/src/cljs/commiteth/handlers.cljs
+++ b/src/cljs/commiteth/handlers.cljs
@@ -430,3 +430,18 @@
  :metrics-loaded
  (fn [db [_]]
    (dissoc db :metrics-loading?)))
+
+(defn close-dropdown []
+  (dispatch [:user-dropdown-close]))
+
+(reg-event-db
+ :user-dropdown-open
+ (fn [db [_]]
+   (.addEventListener js/window "click" close-dropdown)
+   (assoc db :user-dropdown-open? true)))
+
+(reg-event-db
+ :user-dropdown-close
+ (fn [db [_]]
+   (.removeEventListener js/window "click" close-dropdown)
+   (assoc db :user-dropdown-open? false)))

--- a/src/cljs/commiteth/subscriptions.cljs
+++ b/src/cljs/commiteth/subscriptions.cljs
@@ -75,3 +75,8 @@
  :metrics-loading?
    (fn [db _]
      (:metrics-loading? db)))
+
+(reg-sub
+    :user-dropdown-open?
+  (fn [db _]
+    (:user-dropdown-open? db)))


### PR DESCRIPTION
Start an event listener for mouse-click when opening the dropdown menu and stop it when click event is detected to close it.