### PR TITLE
fix warnings in contracts

### DIFF
--- a/contracts/DelegatedCall.sol
+++ b/contracts/DelegatedCall.sol
@@ -41,6 +41,7 @@ contract DelegatedCall {
      */
     function _malloc(uint size) 
         internal 
+        pure
         returns(bytes32 ptr) 
     {
         assembly {

--- a/contracts/MultiSigTokenWalletV1.sol
+++ b/contracts/MultiSigTokenWalletV1.sol
@@ -52,6 +52,7 @@ contract MultiSigTokenWalletV1 is MultiSigWallet {
     * @param _tokenAddr the token contract address
     **/   
     function watch(address _tokenAddr) 
+        public
         ownerExists(msg.sender) 
     {
         uint oldBal = tokenBalances[_tokenAddr];
@@ -68,6 +69,7 @@ contract MultiSigTokenWalletV1 is MultiSigWallet {
     }
 
     function setTokenList(address[] _tokenList) 
+        public
         onlyWallet
     {
         tokens = _tokenList;
@@ -91,7 +93,9 @@ contract MultiSigTokenWalletV1 is MultiSigWallet {
     * @param _token the token contract address
     * @param _data (might be used by child classes)
     */ 
-    function receiveApproval(address _from, uint256 _amount, address _token, bytes _data) {
+    function receiveApproval(address _from, uint256 _amount, address _token, bytes _data) 
+        public 
+    {
         deposit(_from, _amount, _token, _data);
     }
     

--- a/contracts/TokenReg.sol
+++ b/contracts/TokenReg.sol
@@ -2,7 +2,7 @@
 //! By Gav Wood (Ethcore), 2016.
 //! Released under the Apache Licence 2.
 
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.18;
 
 // From Owned.sol
 contract Owned {
@@ -10,7 +10,7 @@ contract Owned {
 
 	event NewOwner(address indexed old, address indexed current);
 
-	function setOwner(address _new) only_owner { NewOwner(owner, _new); owner = _new; }
+	function setOwner(address _new) public only_owner { NewOwner(owner, _new); owner = _new; }
 
 	address public owner = msg.sender;
 }
@@ -36,11 +36,11 @@ contract TokenReg is Owned {
 	event Unregistered(string indexed tla, uint indexed id);
 	event MetaChanged(uint indexed id, bytes32 indexed key, bytes32 value);
 
-	function register(address _addr, string _tla, uint _base, string _name) payable returns (bool) {
+	function register(address _addr, string _tla, uint _base, string _name) public payable returns (bool) {
 		return registerAs(_addr, _tla, _base, _name, msg.sender);
 	}
 
-	function registerAs(address _addr, string _tla, uint _base, string _name, address _owner) payable when_fee_paid when_address_free(_addr) when_is_tla(_tla) when_tla_free(_tla) returns (bool) {
+	function registerAs(address _addr, string _tla, uint _base, string _name, address _owner) public payable when_fee_paid when_address_free(_addr) when_is_tla(_tla) when_tla_free(_tla) returns (bool) {
 		tokens.push(Token(_addr, _tla, _base, _name, _owner));
 		mapFromAddress[_addr] = tokens.length;
 		mapFromTLA[_tla] = tokens.length;
@@ -48,19 +48,19 @@ contract TokenReg is Owned {
 		return true;
 	}
 
-	function unregister(uint _id) only_owner {
+	function unregister(uint _id) public only_owner {
 		Unregistered(tokens[_id].tla, _id);
 		delete mapFromAddress[tokens[_id].addr];
 		delete mapFromTLA[tokens[_id].tla];
 		delete tokens[_id];
 	}
 
-	function setFee(uint _fee) only_owner {
+	function setFee(uint _fee) public only_owner {
 		fee = _fee;
 	}
 
-	function tokenCount() constant returns (uint) { return tokens.length; }
-	function token(uint _id) constant returns (address addr, string tla, uint base, string name, address owner) {
+	function tokenCount() public constant returns (uint) { return tokens.length; }
+	function token(uint _id) public constant returns (address addr, string tla, uint base, string name, address owner) {
 		var t = tokens[_id];
 		addr = t.addr;
 		tla = t.tla;
@@ -69,7 +69,7 @@ contract TokenReg is Owned {
 		owner = t.owner;
 	}
 
-	function fromAddress(address _addr) constant returns (uint id, string tla, uint base, string name, address owner) {
+	function fromAddress(address _addr) public constant returns (uint id, string tla, uint base, string name, address owner) {
 		id = mapFromAddress[_addr] - 1;
 		var t = tokens[id];
 		tla = t.tla;
@@ -78,7 +78,7 @@ contract TokenReg is Owned {
 		owner = t.owner;
 	}
 
-	function fromTLA(string _tla) constant returns (uint id, address addr, uint base, string name, address owner) {
+	function fromTLA(string _tla) public constant returns (uint id, address addr, uint base, string name, address owner) {
 		id = mapFromTLA[_tla] - 1;
 		var t = tokens[id];
 		addr = t.addr;
@@ -87,18 +87,17 @@ contract TokenReg is Owned {
 		owner = t.owner;
 	}
 
-	function meta(uint _id, bytes32 _key) constant returns (bytes32) {
+	function meta(uint _id, bytes32 _key) public constant returns (bytes32) {
 		return tokens[_id].meta[_key];
 	}
 
-	function setMeta(uint _id, bytes32 _key, bytes32 _value) only_token_owner(_id) {
+	function setMeta(uint _id, bytes32 _key, bytes32 _value) public only_token_owner(_id) {
 		tokens[_id].meta[_key] = _value;
 		MetaChanged(_id, _key, _value);
 	}
 
-	function drain() only_owner {
-		if (!msg.sender.send(this.balance))
-			throw;
+	function drain() public only_owner {
+		require (msg.sender.send(this.balance));
 	}
 
 	mapping (address => uint) mapFromAddress;


### PR DESCRIPTION
```text
ricardo@ricardo:~/workspace/commiteth$ truffle compile
Compiling ./contracts/DelegatedCall.sol...
Compiling ./contracts/ERC20.sol...
Compiling ./contracts/MultiSigTokenWalletV1.sol...
Compiling ./contracts/MultiSigWallet.sol...
Compiling ./contracts/TokenReg.sol...

Compilation warnings encountered:

/home/ricardo/workspace/commiteth/contracts/DelegatedCall.sol:64:24: Warning: The "returndatasize" instruction is only available after the Metropolis hard fork. Before that it acts as an invalid instruction.
            outSize := returndatasize
                       ^------------^
,/home/ricardo/workspace/commiteth/contracts/DelegatedCall.sol:69:13: Warning: The "returndatacopy" instruction is only available after the Metropolis hard fork. Before that it acts as an invalid instruction.
            returndatacopy(outDataPtr, 0, outSize)
            ^------------^

Writing artifacts to ./build/contracts
```